### PR TITLE
Align Claude bypass alias with Omarchy (clauded → cx)

### DIFF
--- a/macos/.aliases
+++ b/macos/.aliases
@@ -127,4 +127,5 @@ alias code.='code .'
 # Shortcuts
 # =============================================================================
 alias notes='cd "$HOME/Library/CloudStorage/Dropbox/Obsidian/Allan/"'
-alias clauded='claude --dangerously-skip-permissions'
+# Clear screen + launch Claude Code with permissions bypassed (matches Omarchy's cx)
+alias cx='printf "\033[2J\033[3J\033[H" && claude --permission-mode bypassPermissions'


### PR DESCRIPTION
Renames the macOS `clauded` alias to `cx` so the Claude Code bypass-permissions shortcut is identical across macOS and Omarchy/Linux.

Changes:
- `clauded` → `cx` (same name Omarchy uses)
- Adds the clear-screen prefix Omarchy's `cx` uses
- Switches `--dangerously-skip-permissions` to the equivalent `--permission-mode bypassPermissions`